### PR TITLE
feat: add Python knowledge store and API endpoints

### DIFF
--- a/api/knowledgeList/__init__.py
+++ b/api/knowledgeList/__init__.py
@@ -1,24 +1,23 @@
-import logging
+from __future__ import annotations
 
+import json
 from azure.functions import HttpRequest, HttpResponse
+
+from ..shared.knowledge_store import list_knowledge_files
 
 
 def main(req: HttpRequest) -> HttpResponse:
-    logging.info('Python HTTP trigger function processed a request.')
+    """Return metadata for all knowledge files in a container."""
 
-    name = req.params.get('name')
-    if not name:
+    container_id = req.params.get("containerId")
+    if not container_id:
         try:
-            req_body = req.get_json()
+            body = req.get_json()
+            container_id = body.get("containerId")
         except ValueError:
-            pass
-        else:
-            name = req_body.get('name')
+            container_id = None
+    if not container_id:
+        return HttpResponse("Missing containerId", status_code=400)
 
-    if name:
-        return HttpResponse(f"Hello, {name}. This HTTP triggered function executed successfully.")
-    else:
-        return HttpResponse(
-            "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.",
-            status_code=200
-        )
+    files = list_knowledge_files(container_id)
+    return HttpResponse(json.dumps(files), mimetype="application/json", status_code=200)

--- a/api/knowledgeUpload/__init__.py
+++ b/api/knowledgeUpload/__init__.py
@@ -1,24 +1,43 @@
-import logging
+from __future__ import annotations
 
+import base64
+import json
+from pathlib import Path
 from azure.functions import HttpRequest, HttpResponse
+
+from ..shared.knowledge_store import add_knowledge_file, delete_knowledge_file
+
+KNOWLEDGE_ROOT = Path(__file__).resolve().parent.parent / "knowledge"
 
 
 def main(req: HttpRequest) -> HttpResponse:
-    logging.info('Python HTTP trigger function processed a request.')
+    """Upload a knowledge base file and persist it."""
 
-    name = req.params.get('name')
-    if not name:
-        try:
-            req_body = req.get_json()
-        except ValueError:
-            pass
-        else:
-            name = req_body.get('name')
+    try:
+        body = req.get_json()
+    except ValueError:
+        return HttpResponse("Invalid JSON body", status_code=400)
 
-    if name:
-        return HttpResponse(f"Hello, {name}. This HTTP triggered function executed successfully.")
-    else:
-        return HttpResponse(
-            "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.",
-            status_code=200
-        )
+    container_id = body.get("containerId")
+    file = body.get("file")
+    if not container_id or not file:
+        return HttpResponse("Missing containerId or file", status_code=400)
+
+    try:
+        metadata = add_knowledge_file(container_id, file)
+    except ValueError as exc:
+        return HttpResponse(str(exc), status_code=404)
+
+    knowledge_dir = KNOWLEDGE_ROOT / container_id
+    knowledge_dir.mkdir(parents=True, exist_ok=True)
+    ext = Path(file["name"]).suffix
+    file_path = knowledge_dir / f"{metadata['id']}{ext}"
+
+    try:
+        content_bytes = base64.b64decode(file.get("base64Content", ""))
+        file_path.write_bytes(content_bytes)
+    except Exception as exc:  # pragma: no cover - defensive cleanup
+        delete_knowledge_file(container_id, metadata["id"])
+        return HttpResponse(f"Failed to save file: {exc}", status_code=500)
+
+    return HttpResponse(json.dumps(metadata), status_code=200, mimetype="application/json")

--- a/api/shared/knowledge_store.py
+++ b/api/shared/knowledge_store.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+"""In-memory knowledge base store.
+
+This module mirrors the behavior of the former TypeScript implementation
+(api/src/shared/knowledge.ts).  It keeps metadata for knowledge files in
+memory and stores the base64-encoded file contents separately.  The data
+is **not** persistent and will be lost when the process restarts.
+"""
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class KnowledgeFile:
+    """Metadata describing an uploaded knowledge base file."""
+
+    id: str
+    name: str
+    type: str
+    size: int
+    uploadDate: str
+
+
+@dataclass
+class Container:
+    """Container holding a list of knowledge files."""
+
+    id: str
+    knowledgeBase: List[KnowledgeFile]
+
+
+@dataclass
+class AppStatePayload:
+    containers: List[Container]
+    branding: Dict[str, Any]
+    availableModels: List[Any]
+
+
+# Global in-memory state
+app_state: Optional[AppStatePayload] = None
+knowledge_files_content: Dict[str, str] = {}
+
+
+def _ensure_state_loaded() -> None:
+    """Lazy-initialize the in-memory state."""
+
+    global app_state, knowledge_files_content
+    if app_state is not None:
+        return
+
+    logging.info("Initializing in-memory backend state for the first time.")
+    app_state = AppStatePayload(containers=[], branding={}, availableModels=[])
+    knowledge_files_content = {}
+
+
+def _get_container(container_id: str) -> Optional[Container]:
+    _ensure_state_loaded()
+    return next((c for c in app_state.containers if c.id == container_id), None)
+
+
+def list_knowledge_files(container_id: str) -> List[Dict[str, Any]]:
+    """Return metadata for all knowledge files of *container_id*."""
+
+    container = _get_container(container_id)
+    if not container:
+        return []
+    return [asdict(f) for f in container.knowledgeBase]
+
+
+def add_knowledge_file(container_id: str, file_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Add a file to the knowledge base of *container_id*.
+
+    *file_data* must contain ``name``, ``type``, ``size`` and
+    ``base64Content`` fields.
+    """
+
+    container = _get_container(container_id)
+    if container is None:
+        raise ValueError(f"Container with ID {container_id} not found.")
+
+    new_file = KnowledgeFile(
+        id=f"file-{int(datetime.utcnow().timestamp()*1000)}-{uuid.uuid4().hex[:8]}",
+        name=file_data["name"],
+        type=file_data["type"],
+        size=int(file_data["size"]),
+        uploadDate=datetime.utcnow().isoformat(),
+    )
+
+    container.knowledgeBase.append(new_file)
+    knowledge_files_content[new_file.id] = file_data.get("base64Content", "")
+    return asdict(new_file)
+
+
+def delete_knowledge_file(container_id: str, file_id: str) -> None:
+    """Remove a file from the knowledge base."""
+
+    container = _get_container(container_id)
+    if container:
+        container.knowledgeBase = [f for f in container.knowledgeBase if f.id != file_id]
+    knowledge_files_content.pop(file_id, None)
+
+
+def get_knowledge_files_with_content(container_id: str) -> List[Dict[str, Any]]:
+    """Return metadata along with base64 content for all files."""
+
+    container = _get_container(container_id)
+    if not container:
+        return []
+    return [
+        {**asdict(f), "base64Content": knowledge_files_content.get(f.id, "")}
+        for f in container.knowledgeBase
+    ]
+
+
+def initialize_state(initial_state: Dict[str, Any]) -> None:
+    """Re-initialize the in-memory state using *initial_state* payload."""
+
+    global app_state, knowledge_files_content
+    logging.info("Backend in-memory state is being re-initialized.")
+
+    containers: List[Container] = []
+    for c in initial_state.get("containers", []):
+        kb = [KnowledgeFile(**f) for f in c.get("knowledgeBase", [])]
+        containers.append(Container(id=c["id"], knowledgeBase=kb))
+
+    app_state = AppStatePayload(
+        containers=containers,
+        branding=initial_state.get("branding", {}),
+        availableModels=initial_state.get("availableModels", []),
+    )
+    knowledge_files_content = {}


### PR DESCRIPTION
## Summary
- port in-memory knowledge store from TypeScript to Python
- implement knowledge list, upload, and delete Azure Functions backed by the store
- save uploaded knowledge files to disk for Gemini access

## Testing
- `npx tsc --noEmit`
- `python -m py_compile api/shared/knowledge_store.py api/knowledgeList/__init__.py api/knowledgeUpload/__init__.py api/knowledgeDelete/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4776b0f0c8327a209d1fe8c2aef49