### PR TITLE
build: add python function app deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Build static frontend
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+
+      # Build and publish Python Function App
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r api/requirements.txt
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - run: |
+          npm install -g azure-functions-core-tools@4 --unsafe-perm true
+          func azure functionapp publish ${{ secrets.FUNCTION_APP_NAME }} --python

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -4,6 +4,9 @@
     "exclude": ["/assets/*", "/api/*"]
   },
   "apiLocation": "api",
+  "platform": {
+    "apiRuntime": "python:3.10"
+  },
   "mimeTypes": {
     ".js": "text/javascript",
     ".css": "text/css"


### PR DESCRIPTION
## Summary
- configure Static Web App for Python API runtime
- build and publish Python Function App via GitHub Actions

## Testing
- `npx tsc --noEmit`
- `pip install -r api/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a47c2133b483278fd99f5c24bcc720