### PR TITLE
Use shared helper for cookie lookup

### DIFF
--- a/api/authCallback/__init__.py
+++ b/api/authCallback/__init__.py
@@ -3,6 +3,7 @@ import msal
 
 from shared.config import MSAL_CLIENT_ID, MSAL_CLIENT_SECRET, MSAL_TENANT_ID, APP_URI
 from shared.session import encrypt_session
+from shared.cookies import get_cookie
 
 
 AUTHORITY = f"https://login.microsoftonline.com/{MSAL_TENANT_ID}"
@@ -15,7 +16,7 @@ def _build_redirect_uri(req: HttpRequest) -> str:
 
 def main(req: HttpRequest) -> HttpResponse:
     code = req.params.get("code")
-    verifier = req.cookies.get("verifier")
+    verifier = get_cookie(req, "verifier")
     if not code or not verifier:
         return HttpResponse("Missing authentication parameters.", status_code=400)
 

--- a/api/authLogout/__init__.py
+++ b/api/authLogout/__init__.py
@@ -3,13 +3,14 @@ import msal
 
 from shared.config import MSAL_CLIENT_ID, MSAL_CLIENT_SECRET, MSAL_TENANT_ID
 from shared.session import decrypt_session
+from shared.cookies import get_cookie
 
 
 AUTHORITY = f"https://login.microsoftonline.com/{MSAL_TENANT_ID}"
 
 
 def main(req: HttpRequest) -> HttpResponse:
-    session_cookie = req.cookies.get("session")
+    session_cookie = get_cookie(req, "session")
 
     if session_cookie:
         try:

--- a/api/graphProxy/__init__.py
+++ b/api/graphProxy/__init__.py
@@ -17,6 +17,7 @@ from azure.functions import HttpRequest, HttpResponse
 
 from ..shared.config import MSAL_CLIENT_ID, MSAL_CLIENT_SECRET, MSAL_TENANT_ID
 from ..shared.session import decrypt_session
+from ..shared.cookies import get_cookie
 
 
 AUTHORITY = f"https://login.microsoftonline.com/{MSAL_TENANT_ID}"
@@ -36,7 +37,7 @@ async def main(req: HttpRequest) -> HttpResponse:
     if not path:
         return HttpResponse("Missing Graph path", status_code=400)
 
-    session_token: Optional[str] = req.cookies.get("session")
+    session_token: Optional[str] = get_cookie(req, "session")
     if not session_token:
         return HttpResponse("Unauthorized", status_code=401)
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,6 @@
 # azure-monitor-opentelemetry 
 
 azure-functions
-msal
+msal>=1.33.0
 cryptography
 httpx

--- a/api/shared/cookies.py
+++ b/api/shared/cookies.py
@@ -1,0 +1,11 @@
+from http.cookies import SimpleCookie
+from azure.functions import HttpRequest
+from typing import Optional
+
+
+def get_cookie(req: HttpRequest, name: str) -> Optional[str]:
+    raw = req.headers.get("Cookie", "")
+    jar = SimpleCookie()
+    jar.load(raw)
+    return jar[name].value if name in jar else None
+

--- a/api/userProfile/__init__.py
+++ b/api/userProfile/__init__.py
@@ -10,13 +10,14 @@ from azure.functions import HttpRequest, HttpResponse
 
 from ..shared.config import MSAL_CLIENT_ID, MSAL_CLIENT_SECRET, MSAL_TENANT_ID
 from ..shared.session import decrypt_session
+from ..shared.cookies import get_cookie
 
 AUTHORITY = f"https://login.microsoftonline.com/{MSAL_TENANT_ID}"
 GRAPH_ROOT = "https://graph.microsoft.com/v1.0"
 
 
 async def main(req: HttpRequest) -> HttpResponse:
-    session_token: Optional[str] = req.cookies.get("session")
+    session_token: Optional[str] = get_cookie(req, "session")
     if not session_token:
         return HttpResponse("Unauthorized", status_code=401)
 


### PR DESCRIPTION
## Summary
- add shared `get_cookie` helper for parsing cookies
- switch API functions to use `get_cookie` instead of `req.cookies`
- pin msal dependency to 1.33.0+ for PKCE support

## Testing
- `npx tsc --noEmit`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a48f7845e88327a5466f0923f25a97